### PR TITLE
fix(tsconfig): Set `moduleResolution` to `node`

### DIFF
--- a/.changeset/cold-crabs-hammer.md
+++ b/.changeset/cold-crabs-hammer.md
@@ -1,0 +1,5 @@
+---
+"@cprussin/tsconfig": patch
+---
+
+Set `moduleResolution` to `node` so that next.js doesn't do it in consuming tsconfig files

--- a/packages/tsconfig/src/nextjs.json
+++ b/packages/tsconfig/src/nextjs.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./react.json",
   "compilerOptions": {
+    "moduleResolution": "node",
     "plugins": [{ "name": "next" }]
   }
 }


### PR DESCRIPTION
This needs to be set and if it's not here, then next will add it to consuming `tsconfig.json` files automatically.  So this PR just prevents next from needing to do that.