### PR TITLE
fix(jest-config): only collect coverage from source files

### DIFF
--- a/.changeset/slimy-cars-tickle.md
+++ b/.changeset/slimy-cars-tickle.md
@@ -1,0 +1,5 @@
+---
+"@cprussin/jest-config": patch
+---
+
+Only try to collect coverage from source files (files with extension .ts, .js, .tsx, or .jsx)

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -279,7 +279,7 @@ const config = async (extra: ExtraConfigs): Promise<Config.InitialOptions> =>
       },
     },
     coverageReporters: ["json", "lcov", "text", "cobertura"],
-    collectCoverageFrom: ["<rootDir>/src/**/*"],
+    collectCoverageFrom: ["<rootDir>/src/**/*.(t|j)s?(x)"],
     projects: [
       await withExtra(extra.unit, {
         displayName: {


### PR DESCRIPTION
Previously we matched any file under `src` which caused jest to try to collect coverage on stuff like json files, etc.