### PR TITLE
fix: don't use jsdom in integration tests

### DIFF
--- a/.changeset/rare-hairs-grow.md
+++ b/.changeset/rare-hairs-grow.md
@@ -1,0 +1,5 @@
+---
+"@cprussin/jest-config": patch
+---
+
+Don't use jsdom for integration tests

--- a/packages/jest-config/src/web.ts
+++ b/packages/jest-config/src/web.ts
@@ -39,10 +39,4 @@ export const web = (extra: ExtraConfigs = {}): Promise<Config.InitialOptions> =>
         ...extra.unit?.config,
       },
     },
-    integration: {
-      config: {
-        ...domConfig,
-        ...extra.integration?.config,
-      },
-    },
   });


### PR DESCRIPTION
Integration tests should be written with e.g. puppeteer so they should run in node, not in the browser