### PR TITLE
feat(eslint-config): disallow typescript enums

### DIFF
--- a/.changeset/shaky-numbers-fail.md
+++ b/.changeset/shaky-numbers-fail.md
@@ -1,0 +1,5 @@
+---
+"@cprussin/eslint-config": minor
+---
+
+added an eslint config rule to error whenever a typescript enum is found to be used.

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -81,7 +81,6 @@ const compat = new FlatCompat({
   resolvePluginsRelativeTo: import.meta.dirname,
 });
 
-
 const match = (
   files: string[],
   configs: FlatConfig.ConfigArray,

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -81,6 +81,7 @@ const compat = new FlatCompat({
   resolvePluginsRelativeTo: import.meta.dirname,
 });
 
+
 const match = (
   files: string[],
   configs: FlatConfig.ConfigArray,
@@ -174,6 +175,14 @@ export const base: FlatConfig.ConfigArray = [
           "import/consistent-type-specifier-style": [
             "error",
             "prefer-top-level",
+          ],
+          "no-restricted-syntax": [
+            "error",
+            {
+              selector: "TSEnumDeclaration",
+              message:
+                "TypeScript enums are disallowed. Use union types or const objects instead.",
+            },
           ],
         },
       },


### PR DESCRIPTION
Added a rule to disallow usage of `enum MyEnum` in TypeScript, for various reasons documented [in this writeup](https://www.totaltypescript.com/why-i-dont-like-typescript-enums)

**Screenshot of rule error**

<img width="996" height="446" alt="typescript-enum-disablement" src="https://github.com/user-attachments/assets/7fc16e73-87e1-4bb7-b748-a1f23034aaa3" />
